### PR TITLE
Fix broken github links in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "description": "sfdx plugins by Shane",
   "main": "index.js",
   "author": "Shane McLaughlin @mshanemc",
-  "repository": "mshanemc/sfdx-msm-plugin",
+  "repository": "mshanemc/sfdx-msm-plugins",
   "bugs": {
-    "url": "https://github.com/mshanemc/sfdx-msm-plugin/issues"
+    "url": "https://github.com/mshanemc/sfdx-msm-plugins/issues"
   },
   "keywords": [
     "force.com",


### PR DESCRIPTION
This should fix the broken links on https://www.npmjs.com/package/sfdx-msm-plugin

Currently they come up 404 because of the missing trailing 's' in the repository name.